### PR TITLE
added verification for valid keys to determine where quotes are required

### DIFF
--- a/pkg/pcl2pulumi/pcl2pulumi_test.go
+++ b/pkg/pcl2pulumi/pcl2pulumi_test.go
@@ -52,6 +52,26 @@ func TestOperatorPy(t *testing.T) {
 	assertion.Equal(string(pyExpected), string(py), "python operator codegen is incorrect")
 }
 
+func TestMinReproPy(t *testing.T) {
+	assertion := assert.New(t)
+
+	pcl, err := ioutil.ReadFile("../../testdata/doubleQuotes.pp")
+	assertion.NoError(err)
+
+	_, err = Pcl2Pulumi(string(pcl), "../../testdata/k8sOperator/main", "python")
+	assertion.NoError(err)
+}
+
+func TestSpecialCharPy(t *testing.T) {
+	assertion := assert.New(t)
+
+	pcl, err := ioutil.ReadFile("../../testdata/specialChar.pp")
+	assertion.NoError(err)
+
+	_, err = Pcl2Pulumi(string(pcl), "../../testdata/specialChar", "python")
+	assertion.NoError(err)
+}
+
 // TYPESCRIPT CODEGEN TESTS
 
 func TestNamespaceTs(t *testing.T) {
@@ -96,6 +116,26 @@ func TestOperatorTs(t *testing.T) {
 	assertion.NoError(err)
 
 	assertion.Equal(string(tsExpected), string(ts), "typescript operator codegen is incorrect")
+}
+
+func TestMinReproTs(t *testing.T) {
+	assertion := assert.New(t)
+
+	pcl, err := ioutil.ReadFile("../../testdata/doubleQuotes.pp")
+	assertion.NoError(err)
+
+	_, err = Pcl2Pulumi(string(pcl), "../../testdata/k8sOperator/main", "nodejs")
+	assertion.NoError(err)
+}
+
+func TestSpecialCharTs(t *testing.T) {
+	assertion := assert.New(t)
+
+	pcl, err := ioutil.ReadFile("../../testdata/specialChar.pp")
+	assertion.NoError(err)
+
+	_, err = Pcl2Pulumi(string(pcl), "../../testdata/specialChar", "nodejs")
+	assertion.NoError(err)
 }
 
 // C# CODEGEN TESTS
@@ -151,6 +191,26 @@ func TestOperatorCs(t *testing.T) {
 	assertion.NoError(err)
 
 	assertion.Equal(string(csExpected), string(cs), "dotnet operator codegen is incorrect")
+}
+
+func TestMinReproCs(t *testing.T) {
+	assertion := assert.New(t)
+
+	pcl, err := ioutil.ReadFile("../../testdata/doubleQuotes.pp")
+	assertion.NoError(err)
+
+	_, err = Pcl2Pulumi(string(pcl), "../../testdata/k8sOperator/main", "dotnet")
+	assertion.NoError(err)
+}
+
+func TestSpecialCharCs(t *testing.T) {
+	assertion := assert.New(t)
+
+	pcl, err := ioutil.ReadFile("../../testdata/specialChar.pp")
+	assertion.NoError(err)
+
+	_, err = Pcl2Pulumi(string(pcl), "../../testdata/specialChar", "dotnet")
+	assertion.NoError(err)
 }
 
 // GOLANG CODEGEN TESTS
@@ -219,5 +279,15 @@ func TestMinRepro(t *testing.T) {
 	assertion.NoError(err)
 
 	_, err = Pcl2Pulumi(string(pcl), "../../testdata/k8sOperator/main", "go")
+	assertion.NoError(err)
+}
+
+func TestSpecialCharGo(t *testing.T) {
+	assertion := assert.New(t)
+
+	pcl, err := ioutil.ReadFile("../../testdata/specialChar.pp")
+	assertion.NoError(err)
+
+	_, err = Pcl2Pulumi(string(pcl), "../../testdata/specialChar", "go")
 	assertion.NoError(err)
 }

--- a/pkg/pcl2pulumi/pcl2pulumi_test.go
+++ b/pkg/pcl2pulumi/pcl2pulumi_test.go
@@ -52,13 +52,13 @@ func TestOperatorPy(t *testing.T) {
 	assertion.Equal(string(pyExpected), string(py), "python operator codegen is incorrect")
 }
 
-func TestMinReproPy(t *testing.T) {
+func TestDoubleQuotesPy(t *testing.T) {
 	assertion := assert.New(t)
 
 	pcl, err := ioutil.ReadFile("../../testdata/doubleQuotes.pp")
 	assertion.NoError(err)
 
-	_, err = Pcl2Pulumi(string(pcl), "../../testdata/k8sOperator/main", "python")
+	_, err = Pcl2Pulumi(string(pcl), "../../testdata/doubleQuotes", "python")
 	assertion.NoError(err)
 }
 
@@ -118,13 +118,13 @@ func TestOperatorTs(t *testing.T) {
 	assertion.Equal(string(tsExpected), string(ts), "typescript operator codegen is incorrect")
 }
 
-func TestMinReproTs(t *testing.T) {
+func TestDoubleQuotesTs(t *testing.T) {
 	assertion := assert.New(t)
 
 	pcl, err := ioutil.ReadFile("../../testdata/doubleQuotes.pp")
 	assertion.NoError(err)
 
-	_, err = Pcl2Pulumi(string(pcl), "../../testdata/k8sOperator/main", "nodejs")
+	_, err = Pcl2Pulumi(string(pcl), "../../testdata/doubleQuotes", "nodejs")
 	assertion.NoError(err)
 }
 
@@ -193,13 +193,13 @@ func TestOperatorCs(t *testing.T) {
 	assertion.Equal(string(csExpected), string(cs), "dotnet operator codegen is incorrect")
 }
 
-func TestMinReproCs(t *testing.T) {
+func TestDoubleQuotesCs(t *testing.T) {
 	assertion := assert.New(t)
 
 	pcl, err := ioutil.ReadFile("../../testdata/doubleQuotes.pp")
 	assertion.NoError(err)
 
-	_, err = Pcl2Pulumi(string(pcl), "../../testdata/k8sOperator/main", "dotnet")
+	_, err = Pcl2Pulumi(string(pcl), "../../testdata/doubleQuotes", "dotnet")
 	assertion.NoError(err)
 }
 
@@ -272,13 +272,13 @@ func TestOperatorGo(t *testing.T) {
 	assertion.Equal(string(goExpected), string(_go), "golang operator codegen is incorrect")
 }
 
-func TestMinRepro(t *testing.T) {
+func TestDoubleQuotesGo(t *testing.T) {
 	assertion := assert.New(t)
 
 	pcl, err := ioutil.ReadFile("../../testdata/doubleQuotes.pp")
 	assertion.NoError(err)
 
-	_, err = Pcl2Pulumi(string(pcl), "../../testdata/k8sOperator/main", "go")
+	_, err = Pcl2Pulumi(string(pcl), "../../testdata/doubleQuotes", "go")
 	assertion.NoError(err)
 }
 

--- a/pkg/yaml2pcl/yaml2pcl.go
+++ b/pkg/yaml2pcl/yaml2pcl.go
@@ -5,6 +5,7 @@ package yaml2pcl
 import (
 	"bytes"
 	"fmt"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"io"
 	"io/ioutil"
 	"path/filepath"
@@ -349,7 +350,7 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 			}
 		}
 
-		if strings.Contains(key, "/") || strings.Contains(key, ".") {
+		if !hclsyntax.ValidIdentifier(key) {
 			_, err = fmt.Fprintf(totalPCL, "%q = ", key)
 		} else {
 			_, err = fmt.Fprintf(totalPCL, "%s = ", key)

--- a/pkg/yaml2pcl/yaml2pcl_test.go
+++ b/pkg/yaml2pcl/yaml2pcl_test.go
@@ -169,3 +169,15 @@ func TestNoDoubleQuotes(t *testing.T) {
 	assertion.NoError(err)
 	assertion.Equal(expected, result, "double quotes inserted")
 }
+
+func TestSpecialChar(t *testing.T) {
+	assertion := assert.New(t)
+
+	b, err := ioutil.ReadFile(filepath.Join("../..", "testdata", "specialChar.pp"))
+	assertion.NoError(err)
+	expected := string(b)
+
+	result, err := ConvertFile("../../testdata/specialChar.yaml")
+	assertion.NoError(err)
+	assertion.Equal(expected, result, "double quotes inserted")
+}

--- a/testdata/specialChar.pp
+++ b/testdata/specialChar.pp
@@ -1,0 +1,23 @@
+resource argocd_serverDeployment "kubernetes:apps/v1:Deployment" {
+apiVersion = "apps/v1"
+kind = "Deployment"
+metadata = {
+labels = {
+"app.kubernetes.io/component" = "server"
+"aws:region" = "us-west-2"
+"key%percent" = "percent"
+"key...ellipse" = "ellipse"
+"key{bracket" = "bracket"
+"key}bracket" = "bracket"
+"key*asterix" = "asterix"
+"key?question" = "question"
+"key,comma" = "comma"
+"key&&and" = "and"
+"key||or" = "or"
+"key!not" = "not"
+"key=>geq" = "geq"
+"key==eq" = "equal"
+}
+name = "argocd-server"
+}
+}

--- a/testdata/specialChar.yaml
+++ b/testdata/specialChar.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    aws:region: us-west-2
+    key%percent: percent
+    key...ellipse: ellipse
+    key{bracket: bracket
+    key}bracket: bracket
+    key*asterix: asterix
+    key?question: question
+    key,comma: comma
+    key&&and: and
+    key||or: or
+    key!not: not
+    key=>geq: geq
+    key==eq: equal
+  name: argocd-server


### PR DESCRIPTION
currently works for all invalid characters except % in golang