### PR TITLE
Update yaml2pcl.go

### DIFF
--- a/pkg/yaml2pcl/yaml2pcl.go
+++ b/pkg/yaml2pcl/yaml2pcl.go
@@ -149,7 +149,7 @@ func getHeader(nodes []ast.Node) (string, hcl.Diagnostic) {
 		}
 	}
 
-	header := fmt.Sprintf(`resource %s "kubernetes:%s:%s" `, name, apiVersion, kind)
+	header := fmt.Sprintf(`resource "%s" "kubernetes:%s:%s" `, name, apiVersion, kind)
 	return header, hcl.Diagnostic{}
 }
 


### PR DESCRIPTION
The resource names could include special characters and should be enclosed in quotation marks.