### PR TITLE
Harden string literal escaping

### DIFF
--- a/pkg/kube2pulumi/kube2pulumi_test.go
+++ b/pkg/kube2pulumi/kube2pulumi_test.go
@@ -259,11 +259,17 @@ func TestStringLiteral(t *testing.T) {
 			assertion := assert.New(t)
 			testDir := testutil.MakeTestDir(t, filepath.Join("..", "..", "testdata", "stringLiteral"))
 			kubeManifest := filepath.Join(testDir, "cm.yaml")
-			_, diags, err := Kube2PulumiFile(kubeManifest, "", language)
+			outFile, diags, err := Kube2PulumiFile(kubeManifest, "", language)
 			if diags != nil {
 				assertion.False(diags.HasErrors(), "diagnostics incorrectly displayed for proper yaml")
 			}
 			assertion.NoError(err)
+
+			// Ensure that the generated file does not contain $$. This is a sign that the string literal was not
+			// properly escaped.
+			generated, err := os.ReadFile(outFile)
+			assertion.NoError(err)
+			assertion.NotContains(string(generated), "$$")
 		})
 	}
 }

--- a/pkg/kube2pulumi/kube2pulumi_test.go
+++ b/pkg/kube2pulumi/kube2pulumi_test.go
@@ -252,24 +252,23 @@ func main() {
 }
 
 func TestStringLiteral(t *testing.T) {
-	for language := range testutil.Languages() {
-		language := language
+	for language, ext := range testutil.Languages() {
+		language, ext := language, ext
 		t.Run(language, func(t *testing.T) {
 			t.Parallel()
 			assertion := assert.New(t)
-			testDir := testutil.MakeTestDir(t, filepath.Join("..", "..", "testdata", "stringLiteral"))
+			testdataDir := filepath.Join("..", "..", "testdata", "stringLiteral")
+			testDir := testutil.MakeTestDir(t, testdataDir)
+			expected := filepath.Join(testdataDir, "expected", fmt.Sprintf("expectedStringLiteral%s", ext))
+
 			kubeManifest := filepath.Join(testDir, "cm.yaml")
-			outFile, diags, err := Kube2PulumiFile(kubeManifest, "", language)
+			outPath, diags, err := Kube2PulumiFile(kubeManifest, "", language)
 			if diags != nil {
 				assertion.False(diags.HasErrors(), "diagnostics incorrectly displayed for proper yaml")
 			}
 			assertion.NoError(err)
 
-			// Ensure that the generated file does not contain $$. This is a sign that the string literal was not
-			// properly escaped.
-			generated, err := os.ReadFile(outFile)
-			assertion.NoError(err)
-			assertion.NotContains(string(generated), "$$")
+			testutil.AssertFilesEqual(t, expected, outPath)
 		})
 	}
 }

--- a/pkg/yaml2pcl/yaml2pcl.go
+++ b/pkg/yaml2pcl/yaml2pcl.go
@@ -288,7 +288,7 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 					s = s[:len(s)-1]
 				}
 			}
-			s = strings.ReplaceAll(s, "$", "$$")
+			s = strings.ReplaceAll(s, "${", "$${")
 			strVal := fmt.Sprintf("%q%s", s, suffix)
 			_, err = fmt.Fprintf(totalPCL, "%s\n", strVal)
 			if err != nil {

--- a/testdata/stringLiteral/cm.yaml
+++ b/testdata/stringLiteral/cm.yaml
@@ -24,4 +24,4 @@ kind: ConfigMap
 metadata:
   name: myapp-no-brackets
 data:
-  key: "{\"uid\": \"${datasource\""
+  key: "{\"uid\": \"$datasource\""

--- a/testdata/stringLiteral/cm.yaml
+++ b/testdata/stringLiteral/cm.yaml
@@ -3,4 +3,25 @@ kind: ConfigMap
 metadata:
   name: myapp
 data:
+  key: "{\"uid\": \"$(datasource)\"}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myapp-var
+data:
   key: "{\"uid\": \"${datasource}\"}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myapp-no-end-bracket
+data:
+  key: "{\"uid\": \"${datasource\"}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myapp-no-brackets
+data:
+  key: "{\"uid\": \"${datasource\""

--- a/testdata/stringLiteral/expected/expectedStringLiteral.cs
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using Pulumi;
+using Kubernetes = Pulumi.Kubernetes;
+
+return await Deployment.RunAsync(() => 
+{
+    var myappConfigMap = new Kubernetes.Core.V1.ConfigMap("myappConfigMap", new()
+    {
+        ApiVersion = "v1",
+        Kind = "ConfigMap",
+        Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+        {
+            Name = "myapp",
+        },
+        Data = 
+        {
+            { "key", "{\\\"uid\\\": \\\"$(datasource)\\\"}" },
+        },
+    });
+
+    var myapp_varConfigMap = new Kubernetes.Core.V1.ConfigMap("myapp_varConfigMap", new()
+    {
+        ApiVersion = "v1",
+        Kind = "ConfigMap",
+        Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+        {
+            Name = "myapp-var",
+        },
+        Data = 
+        {
+            { "key", "{\\\"uid\\\": \\\"${datasource}\\\"}" },
+        },
+    });
+
+    var myapp_no_end_bracketConfigMap = new Kubernetes.Core.V1.ConfigMap("myapp_no_end_bracketConfigMap", new()
+    {
+        ApiVersion = "v1",
+        Kind = "ConfigMap",
+        Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+        {
+            Name = "myapp-no-end-bracket",
+        },
+        Data = 
+        {
+            { "key", "{\\\"uid\\\": \\\"${datasource\\\"}" },
+        },
+    });
+
+    var myapp_no_bracketsConfigMap = new Kubernetes.Core.V1.ConfigMap("myapp_no_bracketsConfigMap", new()
+    {
+        ApiVersion = "v1",
+        Kind = "ConfigMap",
+        Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
+        {
+            Name = "myapp-no-brackets",
+        },
+        Data = 
+        {
+            { "key", "{\\\"uid\\\": \\\"${datasource\\\"" },
+        },
+    });
+
+});
+

--- a/testdata/stringLiteral/expected/expectedStringLiteral.cs
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.cs
@@ -56,7 +56,7 @@ return await Deployment.RunAsync(() =>
         },
         Data = 
         {
-            { "key", "{\\\"uid\\\": \\\"${datasource\\\"" },
+            { "key", "{\\\"uid\\\": \\\"$datasource\\\"" },
         },
     });
 

--- a/testdata/stringLiteral/expected/expectedStringLiteral.go
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.go
@@ -56,7 +56,7 @@ func main() {
 				Name: pulumi.String("myapp-no-brackets"),
 			},
 			Data: pulumi.StringMap{
-				"key": pulumi.String(fmt.Sprintf("{\\\"uid\\\": \\\"${datasource\\\"")),
+				"key": pulumi.String(fmt.Sprintf("{\\\"uid\\\": \\\"$datasource\\\"")),
 			},
 		})
 		if err != nil {

--- a/testdata/stringLiteral/expected/expectedStringLiteral.go
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := corev1.NewConfigMap(ctx, "myappConfigMap", &corev1.ConfigMapArgs{
+			ApiVersion: pulumi.String("v1"),
+			Kind:       pulumi.String("ConfigMap"),
+			Metadata: &metav1.ObjectMetaArgs{
+				Name: pulumi.String("myapp"),
+			},
+			Data: pulumi.StringMap{
+				"key": pulumi.String(fmt.Sprintf("{\\\"uid\\\": \\\"$(datasource)\\\"}")),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		_, err = corev1.NewConfigMap(ctx, "myapp_varConfigMap", &corev1.ConfigMapArgs{
+			ApiVersion: pulumi.String("v1"),
+			Kind:       pulumi.String("ConfigMap"),
+			Metadata: &metav1.ObjectMetaArgs{
+				Name: pulumi.String("myapp-var"),
+			},
+			Data: pulumi.StringMap{
+				"key": pulumi.String(fmt.Sprintf("{\\\"uid\\\": \\\"${datasource}\\\"}")),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		_, err = corev1.NewConfigMap(ctx, "myapp_no_end_bracketConfigMap", &corev1.ConfigMapArgs{
+			ApiVersion: pulumi.String("v1"),
+			Kind:       pulumi.String("ConfigMap"),
+			Metadata: &metav1.ObjectMetaArgs{
+				Name: pulumi.String("myapp-no-end-bracket"),
+			},
+			Data: pulumi.StringMap{
+				"key": pulumi.String(fmt.Sprintf("{\\\"uid\\\": \\\"${datasource\\\"}")),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		_, err = corev1.NewConfigMap(ctx, "myapp_no_bracketsConfigMap", &corev1.ConfigMapArgs{
+			ApiVersion: pulumi.String("v1"),
+			Kind:       pulumi.String("ConfigMap"),
+			Metadata: &metav1.ObjectMetaArgs{
+				Name: pulumi.String("myapp-no-brackets"),
+			},
+			Data: pulumi.StringMap{
+				"key": pulumi.String(fmt.Sprintf("{\\\"uid\\\": \\\"${datasource\\\"")),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/testdata/stringLiteral/expected/expectedStringLiteral.java
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.java
@@ -52,7 +52,7 @@ public class App {
             .metadata(ObjectMetaArgs.builder()
                 .name("myapp-no-brackets")
                 .build())
-            .data(Map.of("key", "{\\\"uid\\\": \\\"${datasource\\\""))
+            .data(Map.of("key", "{\\\"uid\\\": \\\"$datasource\\\""))
             .build());
 
     }

--- a/testdata/stringLiteral/expected/expectedStringLiteral.java
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.java
@@ -1,0 +1,59 @@
+package generated_program;
+
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.core.Output;
+import com.pulumi.kubernetes.core_v1.ConfigMap;
+import com.pulumi.kubernetes.core_v1.ConfigMapArgs;
+import com.pulumi.kubernetes.meta_v1.inputs.ObjectMetaArgs;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        var myappConfigMap = new ConfigMap("myappConfigMap", ConfigMapArgs.builder()        
+            .apiVersion("v1")
+            .kind("ConfigMap")
+            .metadata(ObjectMetaArgs.builder()
+                .name("myapp")
+                .build())
+            .data(Map.of("key", "{\\\"uid\\\": \\\"$(datasource)\\\"}"))
+            .build());
+
+        var myapp_varConfigMap = new ConfigMap("myapp_varConfigMap", ConfigMapArgs.builder()        
+            .apiVersion("v1")
+            .kind("ConfigMap")
+            .metadata(ObjectMetaArgs.builder()
+                .name("myapp-var")
+                .build())
+            .data(Map.of("key", "{\\\"uid\\\": \\\"${datasource}\\\"}"))
+            .build());
+
+        var myapp_no_end_bracketConfigMap = new ConfigMap("myapp_no_end_bracketConfigMap", ConfigMapArgs.builder()        
+            .apiVersion("v1")
+            .kind("ConfigMap")
+            .metadata(ObjectMetaArgs.builder()
+                .name("myapp-no-end-bracket")
+                .build())
+            .data(Map.of("key", "{\\\"uid\\\": \\\"${datasource\\\"}"))
+            .build());
+
+        var myapp_no_bracketsConfigMap = new ConfigMap("myapp_no_bracketsConfigMap", ConfigMapArgs.builder()        
+            .apiVersion("v1")
+            .kind("ConfigMap")
+            .metadata(ObjectMetaArgs.builder()
+                .name("myapp-no-brackets")
+                .build())
+            .data(Map.of("key", "{\\\"uid\\\": \\\"${datasource\\\""))
+            .build());
+
+    }
+}

--- a/testdata/stringLiteral/expected/expectedStringLiteral.py
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.py
@@ -35,5 +35,5 @@ myapp_no_brackets_config_map = kubernetes.core.v1.ConfigMap("myapp_no_bracketsCo
         name="myapp-no-brackets",
     ),
     data={
-        "key": "{\\\"uid\\\": \\\"${datasource\\\"",
+        "key": "{\\\"uid\\\": \\\"$datasource\\\"",
     })

--- a/testdata/stringLiteral/expected/expectedStringLiteral.py
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.py
@@ -1,0 +1,39 @@
+import pulumi
+import pulumi_kubernetes as kubernetes
+
+myapp_config_map = kubernetes.core.v1.ConfigMap("myappConfigMap",
+    api_version="v1",
+    kind="ConfigMap",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="myapp",
+    ),
+    data={
+        "key": "{\\\"uid\\\": \\\"$(datasource)\\\"}",
+    })
+myapp_var_config_map = kubernetes.core.v1.ConfigMap("myapp_varConfigMap",
+    api_version="v1",
+    kind="ConfigMap",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="myapp-var",
+    ),
+    data={
+        "key": "{\\\"uid\\\": \\\"${datasource}\\\"}",
+    })
+myapp_no_end_bracket_config_map = kubernetes.core.v1.ConfigMap("myapp_no_end_bracketConfigMap",
+    api_version="v1",
+    kind="ConfigMap",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="myapp-no-end-bracket",
+    ),
+    data={
+        "key": "{\\\"uid\\\": \\\"${datasource\\\"}",
+    })
+myapp_no_brackets_config_map = kubernetes.core.v1.ConfigMap("myapp_no_bracketsConfigMap",
+    api_version="v1",
+    kind="ConfigMap",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="myapp-no-brackets",
+    ),
+    data={
+        "key": "{\\\"uid\\\": \\\"${datasource\\\"",
+    })

--- a/testdata/stringLiteral/expected/expectedStringLiteral.ts
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.ts
@@ -38,6 +38,6 @@ const myapp_no_bracketsConfigMap = new kubernetes.core.v1.ConfigMap("myapp_no_br
         name: "myapp-no-brackets",
     },
     data: {
-        key: `{\"uid\": \"${datasource\"`,
+        key: `{\"uid\": \"$datasource\"`,
     },
 });

--- a/testdata/stringLiteral/expected/expectedStringLiteral.ts
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.ts
@@ -1,0 +1,43 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as kubernetes from "@pulumi/kubernetes";
+
+const myappConfigMap = new kubernetes.core.v1.ConfigMap("myappConfigMap", {
+    apiVersion: "v1",
+    kind: "ConfigMap",
+    metadata: {
+        name: "myapp",
+    },
+    data: {
+        key: `{\"uid\": \"$(datasource)\"}`,
+    },
+});
+const myapp_varConfigMap = new kubernetes.core.v1.ConfigMap("myapp_varConfigMap", {
+    apiVersion: "v1",
+    kind: "ConfigMap",
+    metadata: {
+        name: "myapp-var",
+    },
+    data: {
+        key: `{\"uid\": \"${datasource}\"}`,
+    },
+});
+const myapp_no_end_bracketConfigMap = new kubernetes.core.v1.ConfigMap("myapp_no_end_bracketConfigMap", {
+    apiVersion: "v1",
+    kind: "ConfigMap",
+    metadata: {
+        name: "myapp-no-end-bracket",
+    },
+    data: {
+        key: `{\"uid\": \"${datasource\"}`,
+    },
+});
+const myapp_no_bracketsConfigMap = new kubernetes.core.v1.ConfigMap("myapp_no_bracketsConfigMap", {
+    apiVersion: "v1",
+    kind: "ConfigMap",
+    metadata: {
+        name: "myapp-no-brackets",
+    },
+    data: {
+        key: `{\"uid\": \"${datasource\"`,
+    },
+});


### PR DESCRIPTION
Fixes: #89 

The previous fix for this attempts to escape all `$` symbols, but this should only be done when we have the following sequence of characters: `${`.

For the following examples:
```
# Needs to be escaped:
"{\"uid\": \"${datasource}\"}"
"{\"uid\": \"${datasource\"}"

# No special handling needed:
"{\"uid\": \"$(datasource)\"}"
"{\"uid\": \"$datasource\"}"
```
These are all valid string literals in yaml and only `${` sequences need to be escaped to be properly parsed.