### PR TITLE
Upgrades go-yaml to v1.11.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pulumi/kube2pulumi
 go 1.20
 
 require (
-	github.com/goccy/go-yaml v1.9.5
+	github.com/goccy/go-yaml v1.11.2
 	github.com/hashicorp/hcl/v2 v2.14.0
 	github.com/pulumi/pulumi-java/pkg v0.6.0
 	github.com/pulumi/pulumi/pkg/v3 v3.46.1
@@ -12,8 +12,6 @@ require (
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.8.1
 )
-
-replace github.com/goccy/go-yaml => github.com/goccy/go-yaml v1.8.10
 
 require (
 	cloud.google.com/go v0.107.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -759,8 +759,9 @@ github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY9
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
-github.com/goccy/go-yaml v1.8.10 h1:XpBOLD8cmOZlLYjUFPqSZZ+Ubi4/UKxO2eXyhg5WuAA=
-github.com/goccy/go-yaml v1.8.10/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
+github.com/goccy/go-yaml v1.9.5/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
+github.com/goccy/go-yaml v1.11.2 h1:joq77SxuyIs9zzxEjgyLBugMQ9NEgTWxXfz2wVqwAaQ=
+github.com/goccy/go-yaml v1.11.2/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=

--- a/testdata/testDep/testDep.yaml
+++ b/testdata/testDep/testDep.yaml
@@ -51,6 +51,7 @@ spec:
             - --staticassets
             - /shared/app
             - --repo-server
+            # Test comment
             - argocd-repo-server:8081
             - --dex-server
             - http://argocd-dex-server:5556


### PR DESCRIPTION
This PR upgrades go-yaml to the latest v1.11.2 which has better comment handling within arrays. As the API has changed, our codegen program which interacts with the AST package also needs to be updated. All existing tests were ensured to be passing after this change.

We also needed to update the logic for handling comments, since go-yaml now inputs inline comments into strings, which will result in an incorrectly generated Pulumi program. Since the `stringWithoutComment` methods on the node types are unexported, we need to manually unset/set inline comments so that we can properly convert them to PCL comments, while also ensuring that the string value does not get the comment appended to it.

A test program is also updated to ensure that #101 is fixed by this upgrade.


Fixes: #101 