### PR TITLE
Fix yaml parsing

### DIFF
--- a/pkg/pcl2pulumi/pcl2pulumi.go
+++ b/pkg/pcl2pulumi/pcl2pulumi.go
@@ -105,9 +105,10 @@ func convertPulumi(ppFile *os.File, newFileName string, outputLanguage string) (
 			return "", err
 		}
 	}
-	program, diags, err := pcl.BindProgram(parser.Files)
+	// Enable pcl.AllowMissingProperties to allow converting Kubernetes objects that don't
+	// specify all required fields.
+	program, diags, err := pcl.BindProgram(parser.Files, pcl.AllowMissingProperties)
 	if err != nil {
-		log.Print("failed to bind program: ")
 		return "", err
 	}
 	if len(diags) != 0 {

--- a/pkg/yaml2pcl/yaml2pcl.go
+++ b/pkg/yaml2pcl/yaml2pcl.go
@@ -505,7 +505,7 @@ func addComment(node ast.Node) string {
 	if comments := node.GetComment(); comments != nil {
 		commentVal := ""
 		for _, line := range comments.Comments {
-			commentVal = fmt.Sprintf("# %s", line.Token.Value)
+			commentVal = fmt.Sprintf("#%s", line.Token.Value)
 			// TODO handle multi-line comments
 			break
 		}

--- a/pkg/yaml2pcl/yaml2pcl.go
+++ b/pkg/yaml2pcl/yaml2pcl.go
@@ -121,10 +121,16 @@ func getHeader(nodes []ast.Node) (string, hcl.Diagnostic) {
 	for _, node := range nodes {
 		if mapValNode, ok := node.(*ast.MappingValueNode); ok {
 			if mapValNode.Key.String() == "apiVersion" {
-				comment := mapValNode.Value.GetComment()
-				mapValNode.Value.SetComment(nil)
-				apiVersion = trimQuotes(mapValNode.Value.String())
-				mapValNode.Value.SetComment(comment)
+				val, ok := mapValNode.Value.(*ast.StringNode)
+				if !ok {
+					return "", hcl.Diagnostic{
+						Severity: hcl.DiagnosticSeverity(1),
+						Summary:  "malformed yaml: apiVersion value is wrong type",
+						Detail:   "apiVersion field for the resource needs to be a string",
+					}
+				}
+
+				apiVersion = trimQuotes(val.Value)
 				break
 			}
 		}
@@ -178,32 +184,36 @@ func resourceName(nodes []ast.Node) (string, string) {
 	for _, node := range nodes {
 		if mapValNode, ok := node.(*ast.MappingValueNode); ok {
 			if len(kind) == 0 && mapValNode.Key.String() == "kind" {
-				comment := mapValNode.Value.GetComment()
-				mapValNode.Value.SetComment(nil)
-				kind = mapValNode.Value.String()
-				mapValNode.Value.SetComment(comment)
+				val, ok := mapValNode.Value.(*ast.StringNode)
+				if !ok {
+					return "", ""
+				}
+				kind = val.Value
 				continue
 			}
 			if mapValNode.Key.String() == "metadata" {
 				if mapValNode.Value.Type() == ast.StringType {
-					comment := mapValNode.Value.GetComment()
-					mapValNode.Value.SetComment(nil)
-					name = mapValNode.Value.String()
-					mapValNode.Value.SetComment(comment)
+					val, ok := mapValNode.Value.(*ast.StringNode)
+					if !ok {
+						return "", ""
+					}
+					name = val.Value
 					continue
 				} else {
 					for _, inner := range ast.Filter(ast.MappingValueType, node) {
 						if innerMvNode, ok := inner.(*ast.MappingValueNode); ok {
 							if innerMvNode.Key.String() == "name" {
-								comment := innerMvNode.Value.GetComment()
-								innerMvNode.Value.SetComment(nil)
-								name = innerMvNode.Value.String()
-								innerMvNode.Value.SetComment(comment)
+								val, ok := innerMvNode.Value.(*ast.StringNode)
+								if !ok {
+									return "", ""
+								}
+								name = val.Value
 							} else if innerMvNode.Key.String() == "namespace" {
-								comment := innerMvNode.Value.GetComment()
-								innerMvNode.Value.SetComment(nil)
-								ns = innerMvNode.Value.String()
-								innerMvNode.Value.SetComment(comment)
+								val, ok := innerMvNode.Value.(*ast.StringNode)
+								if !ok {
+									return "", ""
+								}
+								ns = val.Value
 							}
 						}
 					}
@@ -237,13 +247,9 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 	tk := node.GetToken()
 	switch n := node.(type) {
 	case *ast.LiteralNode:
-		// Grab any trailing comment, but set the comment to nil so that it doesn't get pasted into
-		// the string representation of the literal as well.
-		comment := addComment(node)
-		node.SetComment(nil)
+		multLine := n.Value.Value
 
-		multLine := node.String()
-		multLine = strings.TrimPrefix(multLine, "|")
+		// note: PCL heredoc strings must have a trialing newline
 		multLine = strings.TrimSpace(multLine)
 		// Escape any ${} interpolation sequences.
 		multLine = strings.ReplaceAll(multLine, "${", "$${")
@@ -252,6 +258,7 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 			return err
 		}
 
+		comment := addComment(node)
 		if comment != "" {
 			_, err = fmt.Fprintf(totalPCL, "%s", comment)
 			if err != nil {
@@ -259,7 +266,7 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 			}
 		}
 	case *ast.NullNode:
-		_, err = fmt.Fprintf(totalPCL, "%s\n", node)
+		_, err = fmt.Fprintf(totalPCL, "null\n")
 		if err != nil {
 			return err
 		}
@@ -271,7 +278,7 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 			}
 		}
 	case *ast.IntegerNode:
-		_, err = fmt.Fprintf(totalPCL, "%s\n", node)
+		_, err = fmt.Fprintf(totalPCL, "%v\n", n.Value)
 		if err != nil {
 			return err
 		}
@@ -283,7 +290,7 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 			}
 		}
 	case *ast.FloatNode:
-		_, err = fmt.Fprintf(totalPCL, "%s\n", node)
+		_, err = fmt.Fprintf(totalPCL, "%v\n", n.Value)
 		if err != nil {
 			return err
 		}
@@ -296,22 +303,9 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 		}
 	case *ast.StringNode:
 		if tk.Next == nil || tk.Next.Value != ":" {
-			comment := addComment(node)
-			node.SetComment(nil)
-			s := n.String()
-			// Remove leading quote if present.
-			if len(s) > 0 && (s[0] == '"' || s[0] == '\'') {
-				s = s[1:]
-			}
-			// Remove trailing quote if present unless it is escaped.
-			if len(s) > 0 && (s[len(s)-1] == '"' || s[len(s)-1] == '\'') {
-				if len(s) == 1 {
-					s = ""
-				}
-				if len(s) > 1 && s[len(s)-2] != '\\' {
-					s = s[:len(s)-1]
-				}
-			}
+			s := n.Value
+
+			// Escape any ${} interpolation sequences.
 			s = strings.ReplaceAll(s, "${", "$${")
 			strVal := fmt.Sprintf("%q%s", s, suffix)
 			_, err = fmt.Fprintf(totalPCL, "%s\n", strVal)
@@ -319,6 +313,7 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 				return err
 			}
 			// add comments on the same line
+			comment := addComment(node)
 			if comment != "" {
 				_, err = fmt.Fprintf(totalPCL, "%s", comment)
 				if err != nil {
@@ -328,7 +323,7 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 		}
 	case *ast.MergeKeyNode:
 	case *ast.BoolNode:
-		_, err = fmt.Fprintf(totalPCL, "%s\n", node)
+		_, err = fmt.Fprintf(totalPCL, "%v\n", n.Value)
 		if err != nil {
 			return err
 		}
@@ -342,16 +337,9 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 	case *ast.InfinityNode:
 	case *ast.NanNode:
 	case *ast.TagNode:
-		_, err = fmt.Fprintf(totalPCL, "%s\n", node)
+		err = walkToPCL(v, n.Value, totalPCL, "")
 		if err != nil {
 			return err
-		}
-		comment := addComment(node)
-		if comment != "" {
-			_, err = fmt.Fprintf(totalPCL, "%s", comment)
-			if err != nil {
-				return err
-			}
 		}
 	case *ast.DocumentNode:
 		comment := addComment(node)
@@ -368,7 +356,6 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 	case *ast.MappingNode:
 		_, err = fmt.Fprintf(totalPCL, "%s\n", "{")
 		comment := addComment(node)
-		node.SetComment(nil)
 		if comment != "" {
 			_, err = fmt.Fprintf(totalPCL, "%s", comment)
 			if err != nil {
@@ -390,7 +377,6 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 		}
 	case *ast.MappingKeyNode:
 		comment := addComment(node)
-		node.SetComment(nil)
 		if comment != "" {
 			_, err = fmt.Fprintf(totalPCL, "%s", comment)
 			if err != nil {
@@ -403,19 +389,19 @@ func walkToPCL(v Visitor, node ast.Node, totalPCL io.Writer, suffix string) erro
 		}
 	case *ast.MappingValueNode:
 		comment := addComment(node)
-		node.SetComment(nil)
 		if comment != "" {
 			_, err = fmt.Fprintf(totalPCL, "%s", comment)
 			if err != nil {
 				return err
 			}
 		}
-		key := n.Key.String()
-		// trim surrounding quotations if there
-		if len(key) >= 2 {
-			if key[0] == '"' && key[len(key)-1] == '"' {
-				key = key[1 : len(key)-1]
-			}
+		var key string
+		switch nk := n.Key.(type) {
+		case ast.ScalarNode:
+			key = fmt.Sprintf("%v", nk.GetValue())
+		default:
+			return fmt.Errorf(fmt.Sprintf("unexpected key type: %T\n Please file an issue with the YAML input so we"+
+				"can take a look: https://github.com/pulumi/kube2pulumi/issues/new", n.Key))
 		}
 
 		if !hclsyntax.ValidIdentifier(key) {
@@ -516,10 +502,12 @@ func addComment(node ast.Node) string {
 	/**
 	check for comments here in order to add to the PCL string
 	*/
-	if comment := node.GetComment(); comment != nil {
-		commentVal := strings.TrimSpace(comment.String())
-		if !strings.HasPrefix(commentVal, "#") {
-			commentVal = fmt.Sprintf("# %s", commentVal)
+	if comments := node.GetComment(); comments != nil {
+		commentVal := ""
+		for _, line := range comments.Comments {
+			commentVal = fmt.Sprintf("# %s", line.Token.Value)
+			// TODO handle multi-line comments
+			break
 		}
 		return fmt.Sprintf("%s\n", commentVal)
 	}

--- a/testdata/MultilineString/MultilineString.pp
+++ b/testdata/MultilineString/MultilineString.pp
@@ -28,4 +28,3 @@ Corefile = <<EOF
 EOF
 }
 }
-

--- a/testdata/MultilineString/MultilineString.pp
+++ b/testdata/MultilineString/MultilineString.pp
@@ -8,23 +8,24 @@ namespace = "kube-system"
 data = {
 Corefile = <<EOF
 .:53 {
-        errors
-        health {
-          lameduck 5s
-        }
-        ready
-        kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
-          fallthrough in-addr.arpa ip6.arpa
-        }
-        prometheus :9153
-        forward . UPSTREAMNAMESERVER {
-          max_concurrent 1000
-        }
-        cache 30
-        loop
-        reload
-        loadbalance
-    }STUBDOMAINS
+    errors
+    health {
+      lameduck 5s
+    }
+    ready
+    kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
+      fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    forward . UPSTREAMNAMESERVER {
+      max_concurrent 1000
+    }
+    cache 30
+    loop
+    reload
+    loadbalance
+}STUBDOMAINS
 EOF
 }
 }
+

--- a/testdata/MultilineString/expected/expectedMultilineString.cs
+++ b/testdata/MultilineString/expected/expectedMultilineString.cs
@@ -17,23 +17,23 @@ return await Deployment.RunAsync(() =>
         Data = 
         {
             { "Corefile", @".:53 {
-        errors
-        health {
-          lameduck 5s
-        }
-        ready
-        kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
-          fallthrough in-addr.arpa ip6.arpa
-        }
-        prometheus :9153
-        forward . UPSTREAMNAMESERVER {
-          max_concurrent 1000
-        }
-        cache 30
-        loop
-        reload
-        loadbalance
-    }STUBDOMAINS
+    errors
+    health {
+      lameduck 5s
+    }
+    ready
+    kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
+      fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    forward . UPSTREAMNAMESERVER {
+      max_concurrent 1000
+    }
+    cache 30
+    loop
+    reload
+    loadbalance
+}STUBDOMAINS
 " },
         },
     });

--- a/testdata/MultilineString/expected/expectedMultilineString.go
+++ b/testdata/MultilineString/expected/expectedMultilineString.go
@@ -17,23 +17,23 @@ func main() {
 			},
 			Data: pulumi.StringMap{
 				"Corefile": pulumi.String(`.:53 {
-        errors
-        health {
-          lameduck 5s
-        }
-        ready
-        kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
-          fallthrough in-addr.arpa ip6.arpa
-        }
-        prometheus :9153
-        forward . UPSTREAMNAMESERVER {
-          max_concurrent 1000
-        }
-        cache 30
-        loop
-        reload
-        loadbalance
-    }STUBDOMAINS
+    errors
+    health {
+      lameduck 5s
+    }
+    ready
+    kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
+      fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    forward . UPSTREAMNAMESERVER {
+      max_concurrent 1000
+    }
+    cache 30
+    loop
+    reload
+    loadbalance
+}STUBDOMAINS
 `),
 			},
 		})

--- a/testdata/MultilineString/expected/expectedMultilineString.java
+++ b/testdata/MultilineString/expected/expectedMultilineString.java
@@ -28,23 +28,23 @@ public class App {
                 .build())
             .data(Map.of("Corefile", """
 .:53 {
-        errors
-        health {
-          lameduck 5s
-        }
-        ready
-        kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
-          fallthrough in-addr.arpa ip6.arpa
-        }
-        prometheus :9153
-        forward . UPSTREAMNAMESERVER {
-          max_concurrent 1000
-        }
-        cache 30
-        loop
-        reload
-        loadbalance
-    }STUBDOMAINS
+    errors
+    health {
+      lameduck 5s
+    }
+    ready
+    kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
+      fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    forward . UPSTREAMNAMESERVER {
+      max_concurrent 1000
+    }
+    cache 30
+    loop
+    reload
+    loadbalance
+}STUBDOMAINS
             """))
             .build());
 

--- a/testdata/MultilineString/expected/expectedMultilineString.py
+++ b/testdata/MultilineString/expected/expectedMultilineString.py
@@ -10,22 +10,22 @@ kube_system_coredns_config_map = kubernetes.core.v1.ConfigMap("kube_systemCoredn
     ),
     data={
         "Corefile": """.:53 {
-        errors
-        health {
-          lameduck 5s
-        }
-        ready
-        kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
-          fallthrough in-addr.arpa ip6.arpa
-        }
-        prometheus :9153
-        forward . UPSTREAMNAMESERVER {
-          max_concurrent 1000
-        }
-        cache 30
-        loop
-        reload
-        loadbalance
-    }STUBDOMAINS
+    errors
+    health {
+      lameduck 5s
+    }
+    ready
+    kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
+      fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    forward . UPSTREAMNAMESERVER {
+      max_concurrent 1000
+    }
+    cache 30
+    loop
+    reload
+    loadbalance
+}STUBDOMAINS
 """,
     })

--- a/testdata/MultilineString/expected/expectedMultilineString.ts
+++ b/testdata/MultilineString/expected/expectedMultilineString.ts
@@ -10,23 +10,23 @@ const kube_systemCorednsConfigMap = new kubernetes.core.v1.ConfigMap("kube_syste
     },
     data: {
         Corefile: `.:53 {
-        errors
-        health {
-          lameduck 5s
-        }
-        ready
-        kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
-          fallthrough in-addr.arpa ip6.arpa
-        }
-        prometheus :9153
-        forward . UPSTREAMNAMESERVER {
-          max_concurrent 1000
-        }
-        cache 30
-        loop
-        reload
-        loadbalance
-    }STUBDOMAINS
+    errors
+    health {
+      lameduck 5s
+    }
+    ready
+    kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
+      fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    forward . UPSTREAMNAMESERVER {
+      max_concurrent 1000
+    }
+    cache 30
+    loop
+    reload
+    loadbalance
+}STUBDOMAINS
 `,
     },
 });

--- a/testdata/cilium/expected/expectedCilium.cs
+++ b/testdata/cilium/expected/expectedCilium.cs
@@ -344,8 +344,8 @@ return await Deployment.RunAsync(() =>
                                 "sh",
                                 "-ec",
                                 @"cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt ""${BIN_PATH}/cilium-mount"" $CGROUP_ROOT;
-              rm /hostbin/cilium-mount
+nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt ""${BIN_PATH}/cilium-mount"" $CGROUP_ROOT;
+rm /hostbin/cilium-mount
 ",
                             },
                             VolumeMounts = new[]
@@ -402,8 +402,8 @@ return await Deployment.RunAsync(() =>
                                 "sh",
                                 "-ec",
                                 @"cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-              nsenter --mount=/hostproc/1/ns/mnt ""${BIN_PATH}/cilium-sysctlfix"";
-              rm /hostbin/cilium-sysctlfix
+nsenter --mount=/hostproc/1/ns/mnt ""${BIN_PATH}/cilium-sysctlfix"";
+rm /hostbin/cilium-sysctlfix
 ",
                             },
                             VolumeMounts = new[]
@@ -725,7 +725,7 @@ return await Deployment.RunAsync(() =>
                             Name = "clustermesh-secrets",
                             Projected = new Kubernetes.Types.Inputs.Core.V1.ProjectedVolumeSourceArgs
                             {
-                                DefaultMode = 400,
+                                DefaultMode = 256,
                                 Sources = new[]
                                 {
                                     new Kubernetes.Types.Inputs.Core.V1.VolumeProjectionArgs
@@ -788,7 +788,7 @@ return await Deployment.RunAsync(() =>
                             Name = "hubble-tls",
                             Projected = new Kubernetes.Types.Inputs.Core.V1.ProjectedVolumeSourceArgs
                             {
-                                DefaultMode = 400,
+                                DefaultMode = 256,
                                 Sources = new[]
                                 {
                                     new Kubernetes.Types.Inputs.Core.V1.VolumeProjectionArgs

--- a/testdata/cilium/expected/expectedCilium.go
+++ b/testdata/cilium/expected/expectedCilium.go
@@ -273,7 +273,7 @@ func main() {
 								Command: pulumi.StringArray{
 									pulumi.String("sh"),
 									pulumi.String("-ec"),
-									pulumi.String("cp /usr/bin/cilium-mount /hostbin/cilium-mount;\n              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-mount\" $CGROUP_ROOT;\n              rm /hostbin/cilium-mount\n"),
+									pulumi.String("cp /usr/bin/cilium-mount /hostbin/cilium-mount;\nnsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-mount\" $CGROUP_ROOT;\nrm /hostbin/cilium-mount\n"),
 								},
 								VolumeMounts: corev1.VolumeMountArray{
 									&corev1.VolumeMountArgs{
@@ -316,7 +316,7 @@ func main() {
 								Command: pulumi.StringArray{
 									pulumi.String("sh"),
 									pulumi.String("-ec"),
-									pulumi.String("cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;\n              nsenter --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-sysctlfix\";\n              rm /hostbin/cilium-sysctlfix\n"),
+									pulumi.String("cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;\nnsenter --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-sysctlfix\";\nrm /hostbin/cilium-sysctlfix\n"),
 								},
 								VolumeMounts: corev1.VolumeMountArray{
 									&corev1.VolumeMountArgs{
@@ -564,7 +564,7 @@ func main() {
 							&corev1.VolumeArgs{
 								Name: pulumi.String("clustermesh-secrets"),
 								Projected: &corev1.ProjectedVolumeSourceArgs{
-									DefaultMode: pulumi.Int(400),
+									DefaultMode: pulumi.Int(256),
 									Sources: corev1.VolumeProjectionArray{
 										&corev1.VolumeProjectionArgs{
 											Secret: &corev1.SecretProjectionArgs{
@@ -612,7 +612,7 @@ func main() {
 							&corev1.VolumeArgs{
 								Name: pulumi.String("hubble-tls"),
 								Projected: &corev1.ProjectedVolumeSourceArgs{
-									DefaultMode: pulumi.Int(400),
+									DefaultMode: pulumi.Int(256),
 									Sources: corev1.VolumeProjectionArray{
 										&corev1.VolumeProjectionArgs{
 											Secret: &corev1.SecretProjectionArgs{

--- a/testdata/cilium/expected/expectedCilium.java
+++ b/testdata/cilium/expected/expectedCilium.java
@@ -267,8 +267,8 @@ public class App {
                                     "-ec",
                                     """
 cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
-              rm /hostbin/cilium-mount
+nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+rm /hostbin/cilium-mount
                                     """)
                                 .volumeMounts(                                
                                     VolumeMountArgs.builder()
@@ -307,8 +307,8 @@ cp /usr/bin/cilium-mount /hostbin/cilium-mount;
                                     "-ec",
                                     """
 cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-              nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-              rm /hostbin/cilium-sysctlfix
+nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
+rm /hostbin/cilium-sysctlfix
                                     """)
                                 .volumeMounts(                                
                                     VolumeMountArgs.builder()
@@ -525,7 +525,7 @@ cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
                             VolumeArgs.builder()
                                 .name("clustermesh-secrets")
                                 .projected(ProjectedVolumeSourceArgs.builder()
-                                    .defaultMode(400)
+                                    .defaultMode(256)
                                     .sources(                                    
                                         VolumeProjectionArgs.builder()
                                             .secret(SecretProjectionArgs.builder()
@@ -571,7 +571,7 @@ cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
                             VolumeArgs.builder()
                                 .name("hubble-tls")
                                 .projected(ProjectedVolumeSourceArgs.builder()
-                                    .defaultMode(400)
+                                    .defaultMode(256)
                                     .sources(VolumeProjectionArgs.builder()
                                         .secret(SecretProjectionArgs.builder()
                                             .name("hubble-server-certs")

--- a/testdata/cilium/expected/expectedCilium.py
+++ b/testdata/cilium/expected/expectedCilium.py
@@ -248,8 +248,8 @@ default_cilium_daemon_set = kubernetes.apps.v1.DaemonSet("defaultCiliumDaemonSet
                             "sh",
                             "-ec",
                             """cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
-              rm /hostbin/cilium-mount
+nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+rm /hostbin/cilium-mount
 """,
                         ],
                         volume_mounts=[
@@ -290,8 +290,8 @@ default_cilium_daemon_set = kubernetes.apps.v1.DaemonSet("defaultCiliumDaemonSet
                             "sh",
                             "-ec",
                             """cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-              nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-              rm /hostbin/cilium-sysctlfix
+nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
+rm /hostbin/cilium-sysctlfix
 """,
                         ],
                         volume_mounts=[

--- a/testdata/cilium/expected/expectedCilium.py
+++ b/testdata/cilium/expected/expectedCilium.py
@@ -520,7 +520,7 @@ rm /hostbin/cilium-sysctlfix
                     kubernetes.core.v1.VolumeArgs(
                         name="clustermesh-secrets",
                         projected=kubernetes.core.v1.ProjectedVolumeSourceArgs(
-                            default_mode=400,
+                            default_mode=256,
                             sources=[
                                 kubernetes.core.v1.VolumeProjectionArgs(
                                     secret=kubernetes.core.v1.SecretProjectionArgs(
@@ -568,7 +568,7 @@ rm /hostbin/cilium-sysctlfix
                     kubernetes.core.v1.VolumeArgs(
                         name="hubble-tls",
                         projected=kubernetes.core.v1.ProjectedVolumeSourceArgs(
-                            default_mode=400,
+                            default_mode=256,
                             sources=[kubernetes.core.v1.VolumeProjectionArgs(
                                 secret=kubernetes.core.v1.SecretProjectionArgs(
                                     name="hubble-server-certs",

--- a/testdata/cilium/expected/expectedCilium.ts
+++ b/testdata/cilium/expected/expectedCilium.ts
@@ -248,8 +248,8 @@ const defaultCiliumDaemonSet = new kubernetes.apps.v1.DaemonSet("defaultCiliumDa
                             "sh",
                             "-ec",
                             `cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "\${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
-              rm /hostbin/cilium-mount
+nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "\${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+rm /hostbin/cilium-mount
 `,
                         ],
                         volumeMounts: [
@@ -290,8 +290,8 @@ const defaultCiliumDaemonSet = new kubernetes.apps.v1.DaemonSet("defaultCiliumDa
                             "sh",
                             "-ec",
                             `cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-              nsenter --mount=/hostproc/1/ns/mnt "\${BIN_PATH}/cilium-sysctlfix";
-              rm /hostbin/cilium-sysctlfix
+nsenter --mount=/hostproc/1/ns/mnt "\${BIN_PATH}/cilium-sysctlfix";
+rm /hostbin/cilium-sysctlfix
 `,
                         ],
                         volumeMounts: [
@@ -520,7 +520,7 @@ const defaultCiliumDaemonSet = new kubernetes.apps.v1.DaemonSet("defaultCiliumDa
                     {
                         name: "clustermesh-secrets",
                         projected: {
-                            defaultMode: 400,
+                            defaultMode: 256,
                             sources: [
                                 {
                                     secret: {
@@ -568,7 +568,7 @@ const defaultCiliumDaemonSet = new kubernetes.apps.v1.DaemonSet("defaultCiliumDa
                     {
                         name: "hubble-tls",
                         projected: {
-                            defaultMode: 400,
+                            defaultMode: 256,
                             sources: [{
                                 secret: {
                                     name: "hubble-server-certs",

--- a/testdata/cilium/manifest.yaml
+++ b/testdata/cilium/manifest.yaml
@@ -20,6 +20,9 @@ spec:
   template:
     metadata:
       annotations:
+        # Set app AppArmor's profile to "unconfined". The value of this annotation
+        # can be modified as long users know which profiles they have available
+        # in AppArmor.
         container.apparmor.security.beta.kubernetes.io/cilium-agent: "unconfined"
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: "unconfined"
         container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
@@ -30,278 +33,304 @@ spec:
         app.kubernetes.io/part-of: cilium
     spec:
       containers:
-        - name: cilium-agent
-          image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
-          imagePullPolicy: IfNotPresent
-          command:
-            - cilium-agent
-          args:
-            - --config-dir=/tmp/cilium/config-map
-          startupProbe:
-            httpGet:
-              host: "127.0.0.1"
-              path: /healthz
-              port: 9879
-              scheme: HTTP
-              httpHeaders:
-                - name: "brief"
-                  value: "true"
-            failureThreshold: 105
-            periodSeconds: 2
-            successThreshold: 1
-          livenessProbe:
-            httpGet:
-              host: "127.0.0.1"
-              path: /healthz
-              port: 9879
-              scheme: HTTP
-              httpHeaders:
-                - name: "brief"
-                  value: "true"
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 10
-            timeoutSeconds: 5
-          readinessProbe:
-            httpGet:
-              host: "127.0.0.1"
-              path: /healthz
-              port: 9879
-              scheme: HTTP
-              httpHeaders:
-                - name: "brief"
-                  value: "true"
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 3
-            timeoutSeconds: 5
-          env:
-            - name: K8S_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
-            - name: CILIUM_K8S_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: CILIUM_CLUSTERMESH_CONFIG
-              value: /var/lib/cilium/clustermesh/
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - /cni-uninstall.sh
-          securityContext:
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-            capabilities:
-              add:
-                - CHOWN
-                - KILL
-                - NET_ADMIN
-                - NET_RAW
-                - IPC_LOCK
-                - SYS_MODULE
-                - SYS_ADMIN
-                - SYS_RESOURCE
-                - DAC_OVERRIDE
-                - FOWNER
-                - SETGID
-                - SETUID
-              drop:
-                - ALL
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-            - mountPath: /host/proc/sys/net
-              name: host-proc-sys-net
-            - mountPath: /host/proc/sys/kernel
-              name: host-proc-sys-kernel
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-              mountPropagation: HostToContainer
-            - name: cilium-run
-              mountPath: /var/run/cilium
-            - name: etc-cni-netd
-              mountPath: /host/etc/cni/net.d
-            - name: clustermesh-secrets
-              mountPath: /var/lib/cilium/clustermesh
-              readOnly: true
-            - name: lib-modules
-              mountPath: /lib/modules
-              readOnly: true
-            - name: xtables-lock
-              mountPath: /run/xtables.lock
-            - name: hubble-tls
-              mountPath: /var/lib/cilium/tls/hubble
-              readOnly: true
-            - name: tmp
-              mountPath: /tmp
+      - name: cilium-agent
+        image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
+        imagePullPolicy: IfNotPresent
+        command:
+        - cilium-agent
+        args:
+        - --config-dir=/tmp/cilium/config-map
+        startupProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9879
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          failureThreshold: 105
+          periodSeconds: 2
+          successThreshold: 1
+        livenessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9879
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            host: "127.0.0.1"
+            path: /healthz
+            port: 9879
+            scheme: HTTP
+            httpHeaders:
+            - name: "brief"
+              value: "true"
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 5
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_CLUSTERMESH_CONFIG
+          value: /var/lib/cilium/clustermesh/
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /cni-uninstall.sh
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+            - CHOWN
+            - KILL
+            - NET_ADMIN
+            - NET_RAW
+            - IPC_LOCK
+            - SYS_MODULE
+            - SYS_ADMIN
+            - SYS_RESOURCE
+            - DAC_OVERRIDE
+            - FOWNER
+            - SETGID
+            - SETUID
+            drop:
+            - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Unprivileged containers need to mount /proc/sys/net from the host
+        # to have write access
+        - mountPath: /host/proc/sys/net
+          name: host-proc-sys-net
+        # Unprivileged containers need to mount /proc/sys/kernel from the host
+        # to have write access
+        - mountPath: /host/proc/sys/kernel
+          name: host-proc-sys-kernel
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          # Unprivileged containers can't set mount propagation to bidirectional
+          # in this case we will mount the bpf fs from an init container that
+          # is privileged and set the mount propagation from host to container
+          # in Cilium.
+          mountPropagation: HostToContainer
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        - name: etc-cni-netd
+          mountPath: /host/etc/cni/net.d
+        - name: clustermesh-secrets
+          mountPath: /var/lib/cilium/clustermesh
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+        - name: hubble-tls
+          mountPath: /var/lib/cilium/tls/hubble
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
       initContainers:
-        - name: config
-          image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
-          imagePullPolicy: IfNotPresent
-          command:
-            - cilium
-            - build-config
-          env:
-            - name: K8S_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
-            - name: CILIUM_K8S_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
-          terminationMessagePolicy: FallbackToLogsOnError
-        - name: mount-cgroup
-          image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: CGROUP_ROOT
-              value: /run/cilium/cgroupv2
-            - name: BIN_PATH
-              value: /opt/cni/bin
-          command:
-            - sh
-            - -ec
-            - |
-              cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-              nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
-              rm /hostbin/cilium-mount
-          volumeMounts:
-            - name: hostproc
-              mountPath: /hostproc
-            - name: cni-path
-              mountPath: /hostbin
-          terminationMessagePolicy: FallbackToLogsOnError
-          securityContext:
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-            capabilities:
-              add:
-                - SYS_ADMIN
-                - SYS_CHROOT
-                - SYS_PTRACE
-              drop:
-                - ALL
-        - name: apply-sysctl-overwrites
-          image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: BIN_PATH
-              value: /opt/cni/bin
-          command:
-            - sh
-            - -ec
-            - |
-              cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-              nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-              rm /hostbin/cilium-sysctlfix
-          volumeMounts:
-            - name: hostproc
-              mountPath: /hostproc
-            - name: cni-path
-              mountPath: /hostbin
-          terminationMessagePolicy: FallbackToLogsOnError
-          securityContext:
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-            capabilities:
-              add:
-                - SYS_ADMIN
-                - SYS_CHROOT
-                - SYS_PTRACE
-              drop:
-                - ALL
-        - name: mount-bpf-fs
-          image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
-          imagePullPolicy: IfNotPresent
-          args:
-            - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
-          command:
-            - /bin/bash
-            - -c
-            - --
-          terminationMessagePolicy: FallbackToLogsOnError
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-              mountPropagation: Bidirectional
-        - name: clean-cilium-state
-          image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
-          imagePullPolicy: IfNotPresent
-          command:
-            - /init-container.sh
-          env:
-            - name: CILIUM_ALL_STATE
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: clean-cilium-state
-                  optional: true
-            - name: CILIUM_BPF_STATE
-              valueFrom:
-                configMapKeyRef:
-                  name: cilium-config
-                  key: clean-cilium-bpf-state
-                  optional: true
-          terminationMessagePolicy: FallbackToLogsOnError
-          securityContext:
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-            capabilities:
-              add:
-                - NET_ADMIN
-                - SYS_MODULE
-                - SYS_ADMIN
-                - SYS_RESOURCE
-              drop:
-                - ALL
-          volumeMounts:
-            - name: bpf-maps
-              mountPath: /sys/fs/bpf
-            - name: cilium-cgroup
-              mountPath: /run/cilium/cgroupv2
-              mountPropagation: HostToContainer
-            - name: cilium-run
-              mountPath: /var/run/cilium
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi # wait-for-kube-proxy
-        - name: install-cni-binaries
-          image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
-          imagePullPolicy: IfNotPresent
-          command:
-            - "/install-plugin.sh"
-          resources:
-            requests:
-              cpu: 100m
-              memory: 10Mi
-          securityContext:
-            seLinuxOptions:
-              level: s0
-              type: spc_t
-            capabilities:
-              drop:
-                - ALL
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-            - name: cni-path
-              mountPath: /host/opt/cni/bin # .Values.cni.install
+      - name: config
+        image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
+        imagePullPolicy: IfNotPresent
+        command:
+        - cilium
+        - build-config
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        terminationMessagePolicy: FallbackToLogsOnError
+      # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
+      # We use nsenter command with host's cgroup and mount namespaces enabled.
+      - name: mount-cgroup
+        image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: CGROUP_ROOT
+          value: /run/cilium/cgroupv2
+        - name: BIN_PATH
+          value: /opt/cni/bin
+        command:
+        - sh
+        - -ec
+        # The statically linked Go program binary is invoked to avoid any
+        # dependency on utilities like sh and mount that can be missing on certain
+        # distros installed on the underlying host. Copy the binary to the
+        # same directory where we install cilium cni plugin so that exec permissions
+        # are available.
+        - |-
+          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
+          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
+          rm /hostbin/cilium-mount
+        volumeMounts:
+        - name: hostproc
+          mountPath: /hostproc
+        - name: cni-path
+          mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+            - SYS_ADMIN
+            - SYS_CHROOT
+            - SYS_PTRACE
+            drop:
+            - ALL
+      - name: apply-sysctl-overwrites
+        image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: BIN_PATH
+          value: /opt/cni/bin
+        command:
+        - sh
+        - -ec
+        # The statically linked Go program binary is invoked to avoid any
+        # dependency on utilities like sh that can be missing on certain
+        # distros installed on the underlying host. Copy the binary to the
+        # same directory where we install cilium cni plugin so that exec permissions
+        # are available.
+        - |
+          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
+          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
+          rm /hostbin/cilium-sysctlfix
+        volumeMounts:
+        - name: hostproc
+          mountPath: /hostproc
+        - name: cni-path
+          mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+            - SYS_ADMIN
+            - SYS_CHROOT
+            - SYS_PTRACE
+            drop:
+            - ALL
+      # Mount the bpf fs if it is not mounted. We will perform this task
+      # from a privileged container because the mount propagation bidirectional
+      # only works from privileged containers.
+      - name: mount-bpf-fs
+        image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
+        imagePullPolicy: IfNotPresent
+        args:
+        - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
+        command:
+        - /bin/bash
+        - -c
+        - --
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
+      - name: clean-cilium-state
+        image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
+        imagePullPolicy: IfNotPresent
+        command:
+        - /init-container.sh
+        env:
+        - name: CILIUM_ALL_STATE
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: clean-cilium-state
+              optional: true
+        - name: CILIUM_BPF_STATE
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: clean-cilium-bpf-state
+              optional: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_MODULE
+            - SYS_ADMIN
+            - SYS_RESOURCE
+            drop:
+            - ALL
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          # Required to mount cgroup filesystem from the host to cilium agent pod
+        - name: cilium-cgroup
+          mountPath: /run/cilium/cgroupv2
+          mountPropagation: HostToContainer
+        - name: cilium-run
+          mountPath: /var/run/cilium
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi # wait-for-kube-proxy
+      # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
+      - name: install-cni-binaries
+        image: "quay.io/cilium/cilium:v1.14.2@sha256:6263f3a3d5d63b267b538298dbeb5ae87da3efacf09a2c620446c873ba807d35"
+        imagePullPolicy: IfNotPresent
+        command:
+        - "/install-plugin.sh"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: cni-path
+          mountPath: /host/opt/cni/bin # .Values.cni.install
       restartPolicy: Always
       priorityClassName: system-node-critical
       serviceAccount: "cilium"
@@ -312,84 +341,100 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  k8s-app: cilium
-              topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium
+            topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        - operator: Exists
+      - operator: Exists
       volumes:
-        - name: tmp
-          emptyDir: {}
-        - name: cilium-run
-          hostPath:
-            path: /var/run/cilium
-            type: DirectoryOrCreate
-        - name: bpf-maps
-          hostPath:
-            path: /sys/fs/bpf
-            type: DirectoryOrCreate
-        - name: hostproc
-          hostPath:
-            path: /proc
-            type: Directory
-        - name: cilium-cgroup
-          hostPath:
-            path: /run/cilium/cgroupv2
-            type: DirectoryOrCreate
-        - name: cni-path
-          hostPath:
-            path: /opt/cni/bin
-            type: DirectoryOrCreate
-        - name: etc-cni-netd
-          hostPath:
-            path: /etc/cni/net.d
-            type: DirectoryOrCreate
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
-        - name: xtables-lock
-          hostPath:
-            path: /run/xtables.lock
-            type: FileOrCreate
-        - name: clustermesh-secrets
-          projected:
-            defaultMode: 0400
-            sources:
-              - secret:
-                  name: cilium-clustermesh
-                  optional: true
-              - secret:
-                  name: clustermesh-apiserver-remote-cert
-                  optional: true
-                  items:
-                    - key: tls.key
-                      path: common-etcd-client.key
-                    - key: tls.crt
-                      path: common-etcd-client.crt
-                    - key: ca.crt
-                      path: common-etcd-client-ca.crt
-        - name: host-proc-sys-net
-          hostPath:
-            path: /proc/sys/net
-            type: Directory
-        - name: host-proc-sys-kernel
-          hostPath:
-            path: /proc/sys/kernel
-            type: Directory
-        - name: hubble-tls
-          projected:
-            defaultMode: 0400
-            sources:
-              - secret:
-                  name: hubble-server-certs
-                  optional: true
-                  items:
-                    - key: tls.crt
-                      path: server.crt
-                    - key: tls.key
-                      path: server.key
-                    - key: ca.crt
-                      path: client-ca.crt
+      # For sharing configuration between the "config" initContainer and the agent
+      - name: tmp
+        emptyDir: {}
+        # To keep state between restarts / upgrades
+      - name: cilium-run
+        hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+          # To keep state between restarts / upgrades for bpf maps
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+      # To mount cgroup2 filesystem on the host
+      - name: hostproc
+        hostPath:
+          path: /proc
+          type: Directory
+      # To keep state between restarts / upgrades for cgroup2 filesystem
+      - name: cilium-cgroup
+        hostPath:
+          path: /run/cilium/cgroupv2
+          type: DirectoryOrCreate
+      # To install cilium cni plugin in the host
+      - name: cni-path
+        hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+          # To install cilium cni configuration in the host
+      - name: etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+          # To be able to load kernel modules
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+          # To access iptables concurrently with other processes (e.g. kube-proxy)
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+          # To read the clustermesh configuration
+      - name: clustermesh-secrets
+        projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: cilium-clustermesh
+              optional: true
+              # note: items are not explicitly listed here, since the entries of this secret
+              # depend on the peers configured, and that would cause a restart of all agents
+              # at every addition/removal. Leaving the field empty makes each secret entry
+              # to be automatically projected into the volume as a file whose name is the key.
+          - secret:
+              name: clustermesh-apiserver-remote-cert
+              optional: true
+              items:
+              - key: tls.key
+                path: common-etcd-client.key
+              - key: tls.crt
+                path: common-etcd-client.crt
+              - key: ca.crt
+                path: common-etcd-client-ca.crt
+      - name: host-proc-sys-net
+        hostPath:
+          path: /proc/sys/net
+          type: Directory
+      - name: host-proc-sys-kernel
+        hostPath:
+          path: /proc/sys/kernel
+          type: Directory
+      - name: hubble-tls
+        projected:
+          # note: the leading zero means this number is in octal representation: do not remove it
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: hubble-server-certs
+              optional: true
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              - key: ca.crt
+                path: client-ca.crt

--- a/testdata/stringLiteral/expected/expectedStringLiteral.cs
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.cs
@@ -15,7 +15,7 @@ return await Deployment.RunAsync(() =>
         },
         Data = 
         {
-            { "key", "{\\\"uid\\\": \\\"$(datasource)\\\"}" },
+            { "key", "{\"uid\": \"$(datasource)\"}" },
         },
     });
 
@@ -29,7 +29,7 @@ return await Deployment.RunAsync(() =>
         },
         Data = 
         {
-            { "key", "{\\\"uid\\\": \\\"${datasource}\\\"}" },
+            { "key", "{\"uid\": \"${datasource}\"}" },
         },
     });
 
@@ -43,7 +43,7 @@ return await Deployment.RunAsync(() =>
         },
         Data = 
         {
-            { "key", "{\\\"uid\\\": \\\"${datasource\\\"}" },
+            { "key", "{\"uid\": \"${datasource\"}" },
         },
     });
 
@@ -57,7 +57,7 @@ return await Deployment.RunAsync(() =>
         },
         Data = 
         {
-            { "key", "{\\\"uid\\\": \\\"$datasource\\\"" },
+            { "key", "{\"uid\": \"$datasource\"" },
         },
     });
 

--- a/testdata/stringLiteral/expected/expectedStringLiteral.go
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.go
@@ -15,7 +15,7 @@ func main() {
 				Name: pulumi.String("myapp"),
 			},
 			Data: pulumi.StringMap{
-				"key": pulumi.String("{\\\"uid\\\": \\\"$(datasource)\\\"}"),
+				"key": pulumi.String("{\"uid\": \"$(datasource)\"}"),
 			},
 		})
 		if err != nil {
@@ -28,7 +28,7 @@ func main() {
 				Name: pulumi.String("myapp-var"),
 			},
 			Data: pulumi.StringMap{
-				"key": pulumi.String("{\\\"uid\\\": \\\"${datasource}\\\"}"),
+				"key": pulumi.String("{\"uid\": \"${datasource}\"}"),
 			},
 		})
 		if err != nil {
@@ -41,7 +41,7 @@ func main() {
 				Name: pulumi.String("myapp-no-end-bracket"),
 			},
 			Data: pulumi.StringMap{
-				"key": pulumi.String("{\\\"uid\\\": \\\"${datasource\\\"}"),
+				"key": pulumi.String("{\"uid\": \"${datasource\"}"),
 			},
 		})
 		if err != nil {
@@ -54,7 +54,7 @@ func main() {
 				Name: pulumi.String("myapp-no-brackets"),
 			},
 			Data: pulumi.StringMap{
-				"key": pulumi.String("{\\\"uid\\\": \\\"$datasource\\\""),
+				"key": pulumi.String("{\"uid\": \"$datasource\""),
 			},
 		})
 		if err != nil {

--- a/testdata/stringLiteral/expected/expectedStringLiteral.java
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.java
@@ -25,7 +25,7 @@ public class App {
             .metadata(ObjectMetaArgs.builder()
                 .name("myapp")
                 .build())
-            .data(Map.of("key", "{\\\"uid\\\": \\\"$(datasource)\\\"}"))
+            .data(Map.of("key", "{\"uid\": \"$(datasource)\"}"))
             .build());
 
         var myapp_varConfigMap = new ConfigMap("myapp_varConfigMap", ConfigMapArgs.builder()        
@@ -34,7 +34,7 @@ public class App {
             .metadata(ObjectMetaArgs.builder()
                 .name("myapp-var")
                 .build())
-            .data(Map.of("key", "{\\\"uid\\\": \\\"${datasource}\\\"}"))
+            .data(Map.of("key", "{\"uid\": \"${datasource}\"}"))
             .build());
 
         var myapp_no_end_bracketConfigMap = new ConfigMap("myapp_no_end_bracketConfigMap", ConfigMapArgs.builder()        
@@ -43,7 +43,7 @@ public class App {
             .metadata(ObjectMetaArgs.builder()
                 .name("myapp-no-end-bracket")
                 .build())
-            .data(Map.of("key", "{\\\"uid\\\": \\\"${datasource\\\"}"))
+            .data(Map.of("key", "{\"uid\": \"${datasource\"}"))
             .build());
 
         var myapp_no_bracketsConfigMap = new ConfigMap("myapp_no_bracketsConfigMap", ConfigMapArgs.builder()        
@@ -52,7 +52,7 @@ public class App {
             .metadata(ObjectMetaArgs.builder()
                 .name("myapp-no-brackets")
                 .build())
-            .data(Map.of("key", "{\\\"uid\\\": \\\"$datasource\\\""))
+            .data(Map.of("key", "{\"uid\": \"$datasource\""))
             .build());
 
     }

--- a/testdata/stringLiteral/expected/expectedStringLiteral.py
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.py
@@ -8,7 +8,7 @@ myapp_config_map = kubernetes.core.v1.ConfigMap("myappConfigMap",
         name="myapp",
     ),
     data={
-        "key": "{\\\"uid\\\": \\\"$(datasource)\\\"}",
+        "key": "{\"uid\": \"$(datasource)\"}",
     })
 myapp_var_config_map = kubernetes.core.v1.ConfigMap("myapp_varConfigMap",
     api_version="v1",
@@ -17,7 +17,7 @@ myapp_var_config_map = kubernetes.core.v1.ConfigMap("myapp_varConfigMap",
         name="myapp-var",
     ),
     data={
-        "key": "{\\\"uid\\\": \\\"${datasource}\\\"}",
+        "key": "{\"uid\": \"${datasource}\"}",
     })
 myapp_no_end_bracket_config_map = kubernetes.core.v1.ConfigMap("myapp_no_end_bracketConfigMap",
     api_version="v1",
@@ -26,7 +26,7 @@ myapp_no_end_bracket_config_map = kubernetes.core.v1.ConfigMap("myapp_no_end_bra
         name="myapp-no-end-bracket",
     ),
     data={
-        "key": "{\\\"uid\\\": \\\"${datasource\\\"}",
+        "key": "{\"uid\": \"${datasource\"}",
     })
 myapp_no_brackets_config_map = kubernetes.core.v1.ConfigMap("myapp_no_bracketsConfigMap",
     api_version="v1",
@@ -35,5 +35,5 @@ myapp_no_brackets_config_map = kubernetes.core.v1.ConfigMap("myapp_no_bracketsCo
         name="myapp-no-brackets",
     ),
     data={
-        "key": "{\\\"uid\\\": \\\"$datasource\\\"",
+        "key": "{\"uid\": \"$datasource\"",
     })

--- a/testdata/stringLiteral/expected/expectedStringLiteral.ts
+++ b/testdata/stringLiteral/expected/expectedStringLiteral.ts
@@ -8,7 +8,7 @@ const myappConfigMap = new kubernetes.core.v1.ConfigMap("myappConfigMap", {
         name: "myapp",
     },
     data: {
-        key: "{\\\"uid\\\": \\\"$(datasource)\\\"}",
+        key: "{\"uid\": \"$(datasource)\"}",
     },
 });
 const myapp_varConfigMap = new kubernetes.core.v1.ConfigMap("myapp_varConfigMap", {
@@ -18,7 +18,7 @@ const myapp_varConfigMap = new kubernetes.core.v1.ConfigMap("myapp_varConfigMap"
         name: "myapp-var",
     },
     data: {
-        key: "{\\\"uid\\\": \\\"${datasource}\\\"}",
+        key: "{\"uid\": \"${datasource}\"}",
     },
 });
 const myapp_no_end_bracketConfigMap = new kubernetes.core.v1.ConfigMap("myapp_no_end_bracketConfigMap", {
@@ -28,7 +28,7 @@ const myapp_no_end_bracketConfigMap = new kubernetes.core.v1.ConfigMap("myapp_no
         name: "myapp-no-end-bracket",
     },
     data: {
-        key: "{\\\"uid\\\": \\\"${datasource\\\"}",
+        key: "{\"uid\": \"${datasource\"}",
     },
 });
 const myapp_no_bracketsConfigMap = new kubernetes.core.v1.ConfigMap("myapp_no_bracketsConfigMap", {
@@ -38,6 +38,6 @@ const myapp_no_bracketsConfigMap = new kubernetes.core.v1.ConfigMap("myapp_no_br
         name: "myapp-no-brackets",
     },
     data: {
-        key: "{\\\"uid\\\": \\\"$datasource\\\"",
+        key: "{\"uid\": \"$datasource\"",
     },
 });


### PR DESCRIPTION
This is a stacked PR on top of #107 (the last 3 commits are the new additions) that modifies how we interact with yaml strings in our AST parsing. Instead of using the `String()` method on nodes, which requires mutating the nodes to handle comments properly, this PR updates our codebase to use the `Value` method of the ast nodes instead. This gives us better output with correct formatting, eg. correct handling of octal values of file permissions and better multiline string formatting.

Fixes: #109
Fixes #112 
Fixes: #115